### PR TITLE
Fix UploadFiles Return

### DIFF
--- a/DataSummitSolution/DataSummitWeb/Controllers/DocumentsController.cs
+++ b/DataSummitSolution/DataSummitWeb/Controllers/DocumentsController.cs
@@ -45,6 +45,8 @@ namespace DataSummitWeb.Controllers
             {
                 var tasks = files.Select(file => _azureResourcesService.UploadDataToBlob(file));
                 var results = await Task.WhenAll(tasks);
+
+                uploadedFileURLs = results.ToHashSet();
             }
             catch (Exception ae)
             {


### PR DESCRIPTION
Uploading a file didn't return the blob url.

The task wasn't connected to the return type